### PR TITLE
Drata Compliance Recommendations (Grouped)

### DIFF
--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "default" {
   storage_encrypted       = false
   skip_final_snapshot     = true
   monitoring_interval     = 0
-  publicly_accessible     = true
+  publicly_accessible     = false
 
   tags = merge({
     Name        = "${local.resource_prefix.value}-rds"

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -208,6 +208,7 @@ resource "aws_iam_role_policy" "ec2policy" {
   role = aws_iam_role.ec2role.id
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns
   # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns
 {
   "Version": "2012-10-17",

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -14,7 +14,7 @@ resource "aws_db_instance" "default" {
   username                = "admin"
   password                = var.password
   apply_immediately       = true
-  multi_az                = false
+  multi_az                = true
   backup_retention_period = 0
   # Drata: Specify [aws_db_instance.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups
   storage_encrypted       = true

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -16,6 +16,7 @@ resource "aws_db_instance" "default" {
   apply_immediately       = true
   multi_az                = false
   backup_retention_period = 0
+  # Drata: Specify [aws_db_instance.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups
   storage_encrypted       = true
   skip_final_snapshot     = true
   monitoring_interval     = 0

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -208,6 +208,7 @@ resource "aws_iam_role_policy" "ec2policy" {
   role = aws_iam_role.ec2role.id
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "default" {
   apply_immediately       = true
   multi_az                = false
   backup_retention_period = 0
-  storage_encrypted       = false
+  storage_encrypted       = true
   skip_final_snapshot     = true
   monitoring_interval     = 0
   publicly_accessible     = false

--- a/terraform/aws/ec2.tf
+++ b/terraform/aws/ec2.tf
@@ -136,7 +136,7 @@ resource "aws_subnet" "web_subnet" {
   vpc_id                  = aws_vpc.web_vpc.id
   cidr_block              = "172.16.10.0/24"
   availability_zone       = "${var.region}a"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = merge({
     Name = "${local.resource_prefix.value}-subnet"

--- a/terraform/aws/ec2.tf
+++ b/terraform/aws/ec2.tf
@@ -156,7 +156,7 @@ resource "aws_subnet" "web_subnet2" {
   vpc_id                  = aws_vpc.web_vpc.id
   cidr_block              = "172.16.11.0/24"
   availability_zone       = "${var.region}b"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = merge({
     Name = "${local.resource_prefix.value}-subnet2"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -91,7 +91,7 @@ resource aws_subnet "eks_subnet2" {
   vpc_id                  = aws_vpc.eks_vpc.id
   cidr_block              = "10.10.11.0/24"
   availability_zone       = "${var.region}b"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
   tags = merge({
     Name                                            = "${local.resource_prefix.value}-eks-subnet2"
     "kubernetes.io/cluster/${local.eks_name.value}" = "shared"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -63,7 +63,7 @@ resource aws_subnet "eks_subnet1" {
   vpc_id                  = aws_vpc.eks_vpc.id
   cidr_block              = "10.10.10.0/24"
   availability_zone       = "${var.region}a"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
   tags = merge({
     Name                                            = "${local.resource_prefix.value}-eks-subnet"
     "kubernetes.io/cluster/${local.eks_name.value}" = "shared"

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -4,7 +4,7 @@ resource "aws_elb" "weblb" {
 
   listener {
     instance_port     = 8000
-    instance_protocol = "http"
+    instance_protocol = "HTTPS"
     lb_port           = 80
     lb_protocol       = "HTTPS"
   }

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -6,7 +6,7 @@ resource "aws_elb" "weblb" {
     instance_port     = 8000
     instance_protocol = "http"
     lb_port           = 80
-    lb_protocol       = "http"
+    lb_protocol       = "HTTPS"
   }
 
   health_check {

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -1,5 +1,6 @@
 # Create a new load balancer
 resource "aws_elb" "weblb" {
+  # Drata: Configure [aws_elb.access_logs.enabled] to ensure that security-relevant events are logged to detect malicious activity
   name = "weblb-terraform-elb"
 
   listener {

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -18,6 +18,7 @@ resource "aws_elb" "weblb" {
   }
 
   subnets                     = [aws_subnet.web_subnet.id]
+  # Drata: Configure [aws_elb.subnets] to improve infrastructure availability and resilience. Define at least 2 subnets or availability zones on your load balancer to enable zone redundancy
   security_groups             = [aws_security_group.web-node.id]
   instances                   = [aws_instance.web_host.id]
   cross_zone_load_balancing   = true

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -1,5 +1,6 @@
 # Create a new load balancer
 resource "aws_elb" "weblb" {
+  # Drata: Configure [aws_elb.internal] to true to disable public access. It is recommended to explicitly allow access to trusted users or IPs. Exclude this finding if your business use-case requires ELB V1 to be publicly available
   # Drata: Configure [aws_elb.access_logs.enabled] to ensure that security-relevant events are logged to detect malicious activity
   name = "weblb-terraform-elb"
 

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"
 

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.tls_security_policy] to Policy-Min-TLS-1-2-2019-07 to ensure security policies are configured using the latest secure TLS version
   # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience
   # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled
   domain_name           = "tg-${var.environment}-es"

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience
   # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.node_to_node_encryption.enabled] to true to ensure secure protocols are being used to encrypt resource traffic. This setting ensures communication between OpenSearch cluster nodes is encrypted
   # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.enforce_https] to true to ensure secure protocols are being used to encrypt resource traffic
   # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.tls_security_policy] to Policy-Min-TLS-1-2-2019-07 to ensure security policies are configured using the latest secure TLS version
   # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.enforce_https] to true to ensure secure protocols are being used to encrypt resource traffic
   # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.tls_security_policy] to Policy-Min-TLS-1-2-2019-07 to ensure security policies are configured using the latest secure TLS version
   # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience
   # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -27,6 +27,7 @@ resource "aws_iam_user_policy" "userpolicy" {
   user = "${aws_iam_user.user.name}"
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_user_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns. It is recommended to use group policies over user policies when possible.
   # Drata: Explicitly scope [aws_iam_user_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns. It is recommended to use group policies over user policies when possible.
 {
   "Version": "2012-10-17",

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -27,6 +27,7 @@ resource "aws_iam_user_policy" "userpolicy" {
   user = "${aws_iam_user.user.name}"
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_user_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns. It is recommended to use group policies over user policies when possible.
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/terraform/aws/kms.tf
+++ b/terraform/aws/kms.tf
@@ -1,4 +1,5 @@
 resource "aws_kms_key" "logs_key" {
+  # Drata: Define [aws_kms_key.policy] to restrict access to your resource. Follow the principal of minimum necessary access, ensuring permissions are scoped to trusted entities. Exclude this finding if access to Keys is managed using IAM policies instead of a Key policy
   # key does not have rotation enabled
   description = "${local.resource_prefix.value}-logs bucket key"
 

--- a/terraform/aws/lambda.tf
+++ b/terraform/aws/lambda.tf
@@ -30,6 +30,7 @@ EOF
 }
 
 resource "aws_lambda_function" "analysis_lambda" {
+  # Drata: Configure [aws_lambda_function.vpc_config] to improve network monitoring capabilities and ensure network communication is restricted to trusted sources. Exclude this finding if there is a need for your Lambda Function to access external endpoints
   # lambda have plain text secrets in environment variables
   filename      = "resources/lambda_function_payload.zip"
   function_name = "${local.resource_prefix.value}-analysis"

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -2,6 +2,7 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
   cluster_identifier      = "app1-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 0
+  # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups
   tags = {
     git_commit           = "079fe74f6b96d887c245664fbd8cf676c92f20e5"
     git_file             = "terraform/aws/rds.tf"

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -47,6 +47,7 @@ resource "aws_rds_cluster" "app3-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app4-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app4-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -63,6 +63,7 @@ resource "aws_rds_cluster" "app4-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app5-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app5-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -47,6 +47,7 @@ resource "aws_rds_cluster" "app3-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app4-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app4-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -95,6 +95,7 @@ resource "aws_rds_cluster" "app6-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app7-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app7-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -63,6 +63,7 @@ resource "aws_rds_cluster" "app4-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app5-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app5-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -128,6 +128,7 @@ resource "aws_rds_cluster" "app8-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app9-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app9-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -128,6 +128,7 @@ resource "aws_rds_cluster" "app8-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app9-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app9-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -15,6 +15,7 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app2-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app2-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 1

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -15,6 +15,7 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app2-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app2-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -111,6 +111,7 @@ resource "aws_rds_cluster" "app7-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app8-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app8-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -31,6 +31,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app3-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app3-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -111,6 +111,7 @@ resource "aws_rds_cluster" "app7-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app8-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app8-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -18,6 +18,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
   cluster_identifier      = "app2-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 1
+  # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. It is recommended to configure a non-default value appropriate for your specific use-case. AWS defaults to 7 days
   tags = {
     git_commit           = "079fe74f6b96d887c245664fbd8cf676c92f20e5"
     git_file             = "terraform/aws/rds.tf"

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -1,4 +1,5 @@
 resource "aws_rds_cluster" "app1-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app1-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 0

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -31,6 +31,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app3-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app3-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -95,6 +95,7 @@ resource "aws_rds_cluster" "app6-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app7-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app7-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -1,4 +1,5 @@
 resource "aws_rds_cluster" "app1-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app1-rds-cluster"
   allocated_storage       = 10

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -79,6 +79,7 @@ resource "aws_rds_cluster" "app5-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app6-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app6-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -79,6 +79,7 @@ resource "aws_rds_cluster" "app5-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app6-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app6-rds-cluster"
   allocated_storage       = 10

--- a/terraform/azure/aks.tf
+++ b/terraform/azure/aks.tf
@@ -1,4 +1,5 @@
 resource azurerm_kubernetes_cluster "k8s_cluster" {
+  # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane
   dns_prefix          = "terragoat-${var.environment}"
   location            = var.location
   name                = "terragoat-aks-${var.environment}"

--- a/terraform/azure/aks.tf
+++ b/terraform/azure/aks.tf
@@ -1,4 +1,4 @@
-resource azurerm_kubernetes_cluster "k8s_cluster" {
+resource azurerm_kubernetes_cluster "k8s_cluster" { # Drata:  should be set to any of azure, calico, cilium
   # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane
   dns_prefix          = "terragoat-${var.environment}"
   location            = var.location

--- a/terraform/azure/aks.tf
+++ b/terraform/azure/aks.tf
@@ -1,4 +1,4 @@
-resource azurerm_kubernetes_cluster "k8s_cluster" { # Drata:  should be set to any of azure, calico, cilium
+resource azurerm_kubernetes_cluster "k8s_cluster" { # Drata:  should be set to any of azure, calico, cilium # Drata:  should be set to any of stable, rapid, patch
   # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane
   dns_prefix          = "terragoat-${var.environment}"
   location            = var.location

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -35,7 +35,7 @@ resource "azurerm_application_gateway" "network" {
     cookie_based_affinity = "Disabled"
     path                  = "/path1/"
     port                  = 80
-    protocol              = "Http"
+    protocol              = "Https"
     request_timeout       = 60
   }
 

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -5,7 +5,7 @@ resource "azurerm_application_gateway" "network" {
 
   sku {
     name     = "Standard_Small"
-    tier     = "Standard"
+    tier     = "Standard" # Drata: sku.tier should be set to any of Standard_V2, WAF_V2
     capacity = 2
   }
 

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -1,4 +1,5 @@
 resource "azurerm_application_gateway" "network" {
+  # Drata: Configure [azurerm_application_gateway.ssl_policy] to use latest or secure ciphers for data in transit encryption. It is recommended to select either a predefined or custom policy type. For most use-cases predefined policy types will suffice, if more specific cipher suite requirements are needed, define a custom policy type
   name                = "example-appgateway"
   resource_group_name = "example-resourceGroup"
   location            = "example --West-US"

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -35,7 +35,7 @@ resource "azurerm_application_gateway" "network" {
     cookie_based_affinity = "Disabled"
     path                  = "/path1/"
     port                  = 80
-    protocol              = "Https"
+    protocol              = "https"
     request_timeout       = 60
   }
 

--- a/terraform/azure/instance.tf
+++ b/terraform/azure/instance.tf
@@ -42,6 +42,7 @@ resource azurerm_linux_virtual_machine "linux_machine" {
 }
 
 resource azurerm_windows_virtual_machine "windows_machine" {
+  # Drata: Set [azurerm_windows_virtual_machine.encryption_at_host_enabled] to true to ensure transparent data encryption is enabled. This setting ensures temporary disks, caches, and data flows between Azure VM and Storage are encrypted.
   admin_password        = random_string.password.result
   admin_username        = "tg-${var.environment}"
   location              = var.location

--- a/terraform/azure/key_vault.tf
+++ b/terraform/azure/key_vault.tf
@@ -1,4 +1,5 @@
 resource "azurerm_key_vault" "example" {
+  # Drata: Configure [azurerm_key_vault.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. If your business use-case requires public access, define [microsoft_key_vault.vaults.network_acls] appropriately to restrict access
   name                = "terragoat-key-${var.environment}${random_integer.rnd_int.result}"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -1,4 +1,5 @@
 resource "azurerm_storage_account" "security_storage_account" {
+  # Drata: Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version
   name                      = "securitystorageaccount-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name       = azurerm_resource_group.example.name
   location                  = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -21,7 +21,7 @@ resource "azurerm_mssql_server" "mssql1" {
   name                         = "terragoat-mssql1-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -59,7 +59,7 @@ resource "azurerm_mssql_server" "mssql3" {
   name                         = "mssql3-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -135,7 +135,7 @@ resource "azurerm_mssql_server" "mssql7" {
   name                         = "mssql7-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -78,7 +78,7 @@ resource "azurerm_mssql_server" "mssql4" {
   name                         = "mssql4-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -116,7 +116,7 @@ resource "azurerm_mssql_server" "mssql6" {
   name                         = "mssql6-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -4,6 +4,7 @@ resource "azurerm_storage_account" "security_storage_account" {
   location                  = azurerm_resource_group.example.location
   account_tier              = "Standard"
   account_replication_type  = "LRS"
+  # Drata: Configure [azurerm_storage_account.account_replication_type] to improve infrastructure availability and resilience. To create highly available Storage Accounts, set azurerm_storage_account.account_replication_type to a geo-redundant storage option by selecting one of the following SKUs: ['standard_grs', 'standard_gzrs', 'standard_ragrs', 'standard_ragzrs', 'grs', 'gzrs', 'ragrs', 'ragzrs']
   enable_https_traffic_only = true
   tags = {
     git_commit           = "a1d1c1ce31a1bde6dafa188846d90eca82abe5fd"

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -40,7 +40,7 @@ resource "azurerm_mssql_server" "mssql2" {
   name                         = "mssql2-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -97,7 +97,7 @@ resource "azurerm_mssql_server" "mssql5" {
   name                         = "mssql5-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -56,6 +56,7 @@ resource "azurerm_mssql_server" "mssql2" {
 }
 
 resource "azurerm_mssql_server" "mssql3" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql3-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -37,6 +37,7 @@ resource "azurerm_mssql_server" "mssql1" {
 }
 
 resource "azurerm_mssql_server" "mssql2" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql2-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -1,4 +1,5 @@
 resource "azurerm_storage_account" "security_storage_account" {
+  # Drata: Configure [azurerm_storage_account.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. For Storage Accounts that don't require public access it is recommended to use private endpoints to only grant private access
   # Drata: Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version
   name                      = "securitystorageaccount-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name       = azurerm_resource_group.example.name

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -132,6 +132,7 @@ resource "azurerm_mssql_server" "mssql6" {
 }
 
 resource "azurerm_mssql_server" "mssql7" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql7-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -113,6 +113,7 @@ resource "azurerm_mssql_server" "mssql5" {
 }
 
 resource "azurerm_mssql_server" "mssql6" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql6-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -18,6 +18,7 @@ resource "azurerm_storage_account" "security_storage_account" {
 }
 
 resource "azurerm_mssql_server" "mssql1" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "terragoat-mssql1-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -75,6 +75,7 @@ resource "azurerm_mssql_server" "mssql3" {
 }
 
 resource "azurerm_mssql_server" "mssql4" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql4-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -94,6 +94,7 @@ resource "azurerm_mssql_server" "mssql4" {
 }
 
 resource "azurerm_mssql_server" "mssql5" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql5-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -21,6 +21,7 @@ resource "azurerm_managed_disk" "example" {
 }
 
 resource "azurerm_storage_account" "example" {
+  # Drata: Set [azurerm_storage_account.enable_https_traffic_only] to true to ensure secure protocols are being used to encrypt resource traffic
   name                     = "tgsa${var.environment}${random_integer.rnd_int.result}"
   resource_group_name      = azurerm_resource_group.example.name
   location                 = azurerm_resource_group.example.location

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -37,7 +37,7 @@ resource "azurerm_storage_account" "example" {
     hour_metrics {
       enabled               = true
       include_apis          = true
-      version               = "1.0"
+      version               = "TLS1_2"
       retention_policy_days = 10
     }
     minute_metrics {

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -14,6 +14,7 @@ resource "google_sql_database_instance" "master_instance" {
     }
     backup_configuration {
       enabled = false
+    # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance
     }
   }
 }

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -13,7 +13,7 @@ resource "google_sql_database_instance" "master_instance" {
       }
     }
     backup_configuration {
-      enabled = false
+      enabled = true
     # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance
     }
   }

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -1,4 +1,5 @@
 resource "google_sql_database_instance" "master_instance" {
+  # Drata: Set [google_sql_database_instance.settings.ip_configuration.require_ssl] to True to ensure secure protocols are being used to encrypt resource traffic
   name             = "terragoat-${var.environment}-master"
   database_version = "POSTGRES_11"
   region           = var.region

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -22,6 +22,7 @@ resource "google_bigquery_dataset" "dataset" {
   dataset_id = "terragoat_${var.environment}_dataset"
   access {
     special_group = "allAuthenticatedUsers"
+    # Drata: Explicitly scope [google_bigquery_dataset.access.special_group] to ensure minimum necessary access. Avoid using insecure allow-all ([allusers, allauthenticatedusers]) access patterns
     role          = "READER"
   }
   labels = {

--- a/terraform/gcp/gcs.tf
+++ b/terraform/gcp/gcs.tf
@@ -1,4 +1,5 @@
 resource "google_storage_bucket" "terragoat_website" {
+  # Drata: Set [google_storage_bucket.versioning.enabled] to true to enable infrastructure versioning and prevent accidental deletions and overrides
   name          = "terragot-${var.environment}"
   location      = var.location
   force_destroy = true

--- a/terraform/gcp/gke.tf
+++ b/terraform/gcp/gke.tf
@@ -4,6 +4,7 @@ data "google_compute_zones" "available_zones" {
 }
 
 resource "google_container_cluster" "workload_cluster" {
+  # Drata: Kubernetes provides an additional layer of security for sensitive data, such as Secrets, stored in etcd. Using this functionality, you can use a key managed by your Cloud provider to encrypt data at the etcd layer. This encryption protects against attackers who gain access to an offline copy of etcd. Ensure that [google_container_cluster.database_encryption.state] properties are correctly defined for encrypting secrets
   name               = "terragoat-${var.environment}-cluster"
   logging_service    = "none"
   location           = var.region

--- a/terraform/gcp/gke.tf
+++ b/terraform/gcp/gke.tf
@@ -22,6 +22,7 @@ resource "google_container_cluster" "workload_cluster" {
 }
 
 resource "google_container_node_pool" "custom_node_pool" {
+  # Drata: Set [google_container_node_pool.management.auto_upgrade] to true to automatically update nodes in the cluster to the latest control plane version
   cluster  = google_container_cluster.workload_cluster.name
   location = var.region
 

--- a/terraform/gcp/networks.tf
+++ b/terraform/gcp/networks.tf
@@ -17,6 +17,7 @@ resource "google_compute_subnetwork" "public-subnetwork" {
 }
 
 resource "google_compute_firewall" "allow_all" {
+  # Drata: Configure [google_compute_firewall.log_config] to ensure that security-relevant events are logged to detect malicious activity
   name          = "terragoat-${var.environment}-firewall"
   network       = google_compute_network.vpc.id
   source_ranges = ["0.0.0.0/0"]

--- a/terraform/gcp/networks.tf
+++ b/terraform/gcp/networks.tf
@@ -5,6 +5,7 @@ resource "google_compute_network" "vpc" {
 }
 
 resource "google_compute_subnetwork" "public-subnetwork" {
+  # Drata: Configure [google_compute_subnetwork.log_config] to ensure that security-relevant events are logged to detect malicious activity
   name          = "terragoat-${var.environment}-public-subnetwork"
   ip_cidr_range = "10.0.0.0/24"
   region        = var.region


### PR DESCRIPTION
## Drata identified 86 design gaps in 44 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Test                    | Summary |
| ----------- | ---------- |
| Autoscaling Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Backup Retention Configured | `Critical: 0  High: 0  Moderate: 3  Low: 0  ` |
| Transparent Data-at-Rest Encryption Enabled | `Critical: 0  High: 1  Moderate: 13  Low: 0  ` |
| Cloud Storage Versioning Enabled | `Critical: 0  High: 2  Moderate: 0  Low: 0  ` |
| Zone Redundancy Configured | `Critical: 0  High: 0  Moderate: 13  Low: 1  ` |
| Logging Configuration Enabled | `Critical: 0  High: 0  Moderate: 3  Low: 0  ` |
| Secure TLS/SSL Configuration | `Critical: 10  High: 0  Moderate: 0  Low: 0  ` |
| VPC Configuration | `Critical: 0  High: 0  Moderate: 1  Low: 0  ` |
| TLS Enforced | `Critical: 8  High: 0  Moderate: 0  Low: 0  ` |
| Security Groups Configured | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Network Configurations Restrict Broad Access | `Critical: 1  High: 0  Moderate: 1  Low: 0  ` |
| Public Access Restricted | `Critical: 1  High: 12  Moderate: 6  Low: 0  ` |
| Network Access Denied By Default | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automatic Software Updates | `Critical: 0  High: 0  Moderate: 2  Low: 0  ` |
| Log Integrity | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Strong TLS Ciphers | `Critical: 1  High: 0  Moderate: 0  Low: 0  ` |
| Web Application Firewall | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automated Backups | `Critical: 0  High: 0  Moderate: 1  Low: 0  ` |
| Secure API Version | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Log Retention | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Default Service Accounts Disabled | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Access Policies Restrict Broad Access | `Critical: 6  High: 0  Moderate: 0  Low: 0  ` |
| Role Based Access Control | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Secure Runtime Configurations | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Resource Tagging | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Deletion Protection | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Data Retention | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automatic Cryptographic Key Rotation | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
| Automatic Secret Rotation | `Critical: 0  High: 0  Moderate: 0  Low: 0  ` |
### Remediated (2)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `alertpolicy1` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `alertpolicy2` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `alertpolicy3` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `alertpolicy4` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `alertpolicy5` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `alertpolicy6` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `alertpolicy7` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Moderate | `allow_all` | # Drata: Configure [google_compute_firewall.log_config] to ensure that security-relevant events are logged to detect malicious activity<br> |
| High | `allow_public_read` | # Drata: Set [google_storage_bucket.versioning.enabled] to true to enable infrastructure versioning and prevent accidental deletions and overrides<br> |
| Moderate | `analysis_lambda` | # Drata: Configure [aws_lambda_function.vpc_config] to improve network monitoring capabilities and ensure network communication is restricted to trusted sources. Exclude this finding if there is a need for your Lambda Function to access external endpoints<br> |
| Moderate | `app1-rds-cluster` | # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups<br> # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app2-rds-cluster` | # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. It is recommended to configure a non-default value appropriate for your specific use-case. AWS defaults to 7 days<br> # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app3-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app4-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app5-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app6-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app7-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app8-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app9-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| High | `custom_node_pool` | # Drata: Kubernetes provides an additional layer of security for sensitive data, such as Secrets, stored in etcd. Using this functionality, you can use a key managed by your Cloud provider to encrypt data at the etcd layer. This encryption protects against attackers who gain access to an offline copy of etcd. Ensure that [google_container_cluster.database_encryption.state] properties are correctly defined for encrypting secrets<br> |
| Moderate | `custom_node_pool` | # Drata: Set [google_container_node_pool.management.auto_upgrade] to true to automatically update nodes in the cluster to the latest control plane version<br> |
| Critical | `dataset` | # Drata: Explicitly scope [google_bigquery_dataset.access.special_group] to ensure minimum necessary access. Avoid using insecure allow-all ([allusers, allauthenticatedusers]) access patterns<br> |
| Moderate | `default` | # Drata: Specify [aws_db_instance.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups<br> Set [aws_db_instance.storage_encrypted] to true to ensure transparent data encryption is enabled<br> Set [aws_db_instance.multi_az] to true to improve infrastructure availability and resilience<br> Configure [aws_db_instance.publicly_accessible] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Critical | `ec2role` | # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns<br> # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns<br> |
| Moderate | `eks_subnet1` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| Moderate | `eks_subnet2` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| Critical | `example` | Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Set [azurerm_storage_account.enable_https_traffic_only] to true to ensure secure protocols are being used to encrypt resource traffic<br> |
| High | `generated` | # Drata: Configure [azurerm_key_vault.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. If your business use-case requires public access, define [microsoft_key_vault.vaults.network_acls] appropriately to restrict access<br> |
| Critical | `k8s_cluster` | # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane<br> Set [azurerm_kubernetes_cluster.network_profile.network_policy] to any of ['azure', 'calico', 'cilium'] to define access policy specifications for communication between Pods<br> Set [azurerm_kubernetes_cluster.automatic_channel_upgrade] to any of ['stable', 'rapid', 'patch'] to automatically upgrade AKS cluster to the latest Kubernetes version<br> |
| Critical | `logs_key_alias` | # Drata: Define [aws_kms_key.policy] to restrict access to your resource. Follow the principal of minimum necessary access, ensuring permissions are scoped to trusted entities. Exclude this finding if access to Keys is managed using IAM policies instead of a Key policy<br> |
| Critical | `master_instance` | # Drata: Set [google_sql_database_instance.settings.ip_configuration.require_ssl] to True to ensure secure protocols are being used to encrypt resource traffic<br> # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance<br> Set [google_sql_database_instance.settings.backup_configuration.enabled] to true to ensure that continuous backups are performed to enhance infrastructure resilience and prevent data loss<br> |
| Moderate | `monitoring-framework` | # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled<br> # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience<br> # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.tls_security_policy] to Policy-Min-TLS-1-2-2019-07 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.enforce_https] to true to ensure secure protocols are being used to encrypt resource traffic<br> # Drata: Set [aws_elasticsearch_domain.node_to_node_encryption.enabled] to true to ensure secure protocols are being used to encrypt resource traffic. This setting ensures communication between OpenSearch cluster nodes is encrypted<br> |
| Low | `network` | Zone Redundancy is only available with the following SKU(s): [Standard_V2, WAF_V2]. Ensure that [azurerm_application_gateway.sku.tier] is deployed with one of these SKUs to allow Zone Redundancy<br> Set [azurerm_application_gateway.http_listener.protocol] to Https to ensure secure protocols are being used to encrypt resource traffic<br> Set [azurerm_application_gateway.backend_http_settings.protocol] to https to ensure secure protocols are being used to encrypt resource traffic<br> # Drata: Configure [azurerm_application_gateway.ssl_policy] to use latest or secure ciphers for data in transit encryption. It is recommended to select either a predefined or custom policy type. For most use-cases predefined policy types will suffice, if more specific cipher suite requirements are needed, define a custom policy type<br> |
| Moderate | `public-subnetwork` | # Drata: Configure [google_compute_subnetwork.log_config] to ensure that security-relevant events are logged to detect malicious activity<br> |
| Moderate | `rtbassoc` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| Moderate | `rtbassoc2` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| Moderate | `security_storage_account` | # Drata: Configure [azurerm_storage_account.account_replication_type] to improve infrastructure availability and resilience. To create highly available Storage Accounts, set azurerm_storage_account.account_replication_type to a geo-redundant storage option by selecting one of the following SKUs: ['standard_grs', 'standard_gzrs', 'standard_ragrs', 'standard_ragzrs', 'grs', 'gzrs', 'ragrs', 'ragzrs']<br> # Drata: Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version<br> # Drata: Configure [azurerm_storage_account.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. For Storage Accounts that don't require public access it is recommended to use private endpoints to only grant private access<br> |
| Critical | `user` | # Drata: Explicitly scope [aws_iam_user_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns. It is recommended to use group policies over user policies when possible.<br> # Drata: Explicitly scope [aws_iam_user_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns. It is recommended to use group policies over user policies when possible.<br> |
| Moderate | `weblb` | # Drata: Configure [aws_elb.subnets] to improve infrastructure availability and resilience. Define at least 2 subnets or availability zones on your load balancer to enable zone redundancy<br> # Drata: Configure [aws_elb.access_logs.enabled] to ensure that security-relevant events are logged to detect malicious activity<br> Set [aws_elb.listener.instance_protocol] to HTTPS to ensure secure protocols are being used to encrypt resource traffic<br> Set [aws_elb.listener.lb_protocol] to HTTPS to ensure secure protocols are being used to encrypt resource traffic<br> # Drata: Configure [aws_elb.internal] to true to disable public access. It is recommended to explicitly allow access to trusted users or IPs. Exclude this finding if your business use-case requires ELB V1 to be publicly available<br> |
| Moderate | `windows_machine` | # Drata: Set [azurerm_windows_virtual_machine.encryption_at_host_enabled] to true to ensure transparent data encryption is enabled. This setting ensures temporary disks, caches, and data flows between Azure VM and Storage are encrypted.<br> |
### Unremediated (5)
These 5 design gap(s) cannot be remediated automatically. Details for remediation can be found below and within the comments included in this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `data` | Set [aws_s3_bucket_versioning.versioning_configuration.status] to Enabled to enable infrastructure versioning and prevent accidental deletions and overrides<br> Configure [s3.bucket.public_access_block_configuration] to prevent intentional or incidental public access<br> |
| High | `data_science` | Configure [aws_s3_bucket_acl.acl] to prevent intentional or incidental public access. It is recommended to use [s3.bucket.public_access_block_configuration] to control S3 bucket public access over Canned Access Control Lists (ACLs)<br> |
| Moderate | `financials` | It is recommended to use [s3.bucket.public_access_block_configuration] to control S3 bucket public access over Canned Access Control Lists (ACLs)<br> |
| Moderate | `linux_machine` | Set [azurerm_windows_virtual_machine.encryption_at_host_enabled] to true to ensure transparent data encryption is enabled. This setting ensures temporary disks, caches, and data flows between Azure VM and Storage are encrypted.<br> |
