### PR TITLE
Drata Compliance Recommendations: TLS Enforced

### DIFF
--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -4,7 +4,7 @@ resource "aws_elb" "weblb" {
 
   listener {
     instance_port     = 8000
-    instance_protocol = "http"
+    instance_protocol = "HTTPS"
     lb_port           = 80
     lb_protocol       = "HTTPS"
   }

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -6,7 +6,7 @@ resource "aws_elb" "weblb" {
     instance_port     = 8000
     instance_protocol = "http"
     lb_port           = 80
-    lb_protocol       = "http"
+    lb_protocol       = "HTTPS"
   }
 
   health_check {

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.enforce_https] to true to ensure secure protocols are being used to encrypt resource traffic
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"
 

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.node_to_node_encryption.enabled] to true to ensure secure protocols are being used to encrypt resource traffic. This setting ensures communication between OpenSearch cluster nodes is encrypted
   # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.enforce_https] to true to ensure secure protocols are being used to encrypt resource traffic
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -35,7 +35,7 @@ resource "azurerm_application_gateway" "network" {
     cookie_based_affinity = "Disabled"
     path                  = "/path1/"
     port                  = 80
-    protocol              = "Http"
+    protocol              = "Https"
     request_timeout       = 60
   }
 

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -35,7 +35,7 @@ resource "azurerm_application_gateway" "network" {
     cookie_based_affinity = "Disabled"
     path                  = "/path1/"
     port                  = 80
-    protocol              = "Https"
+    protocol              = "https"
     request_timeout       = 60
   }
 

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -21,6 +21,7 @@ resource "azurerm_managed_disk" "example" {
 }
 
 resource "azurerm_storage_account" "example" {
+  # Drata: Set [azurerm_storage_account.enable_https_traffic_only] to true to ensure secure protocols are being used to encrypt resource traffic
   name                     = "tgsa${var.environment}${random_integer.rnd_int.result}"
   resource_group_name      = azurerm_resource_group.example.name
   location                 = azurerm_resource_group.example.location

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -1,4 +1,5 @@
 resource "google_sql_database_instance" "master_instance" {
+  # Drata: Set [google_sql_database_instance.settings.ip_configuration.require_ssl] to True to ensure secure protocols are being used to encrypt resource traffic
   name             = "terragoat-${var.environment}-master"
   database_version = "POSTGRES_11"
   region           = var.region


### PR DESCRIPTION
## Drata identified 8 design gaps in 5 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 8 |
| High | 0 |
| Moderate | 0 |
| Low | 0 |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `example` | # Drata: Set [azurerm_storage_account.enable_https_traffic_only] to true to ensure secure protocols are being used to encrypt resource traffic<br> |
| Critical | `master_instance` | # Drata: Set [google_sql_database_instance.settings.ip_configuration.require_ssl] to True to ensure secure protocols are being used to encrypt resource traffic<br> |
| Critical | `monitoring-framework` | # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.enforce_https] to true to ensure secure protocols are being used to encrypt resource traffic<br> # Drata: Set [aws_elasticsearch_domain.node_to_node_encryption.enabled] to true to ensure secure protocols are being used to encrypt resource traffic. This setting ensures communication between OpenSearch cluster nodes is encrypted<br> |
| Critical | `network` | Set [azurerm_application_gateway.http_listener.protocol] to Https to ensure secure protocols are being used to encrypt resource traffic<br> Set [azurerm_application_gateway.backend_http_settings.protocol] to https to ensure secure protocols are being used to encrypt resource traffic<br> |
| Critical | `weblb` | Set [aws_elb.listener.instance_protocol] to HTTPS to ensure secure protocols are being used to encrypt resource traffic<br> Set [aws_elb.listener.lb_protocol] to HTTPS to ensure secure protocols are being used to encrypt resource traffic<br> |
