### PR TITLE
Drata Compliance Recommendations: Network Configurations Restrict Broad Access

### DIFF
--- a/terraform/azure/aks.tf
+++ b/terraform/azure/aks.tf
@@ -1,4 +1,5 @@
 resource azurerm_kubernetes_cluster "k8s_cluster" {
+  # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane
   dns_prefix          = "terragoat-${var.environment}"
   location            = var.location
   name                = "terragoat-aks-${var.environment}"

--- a/terraform/azure/aks.tf
+++ b/terraform/azure/aks.tf
@@ -1,4 +1,4 @@
-resource azurerm_kubernetes_cluster "k8s_cluster" {
+resource azurerm_kubernetes_cluster "k8s_cluster" { # Drata:  should be set to any of azure, calico, cilium
   # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane
   dns_prefix          = "terragoat-${var.environment}"
   location            = var.location


### PR DESCRIPTION
## Drata identified 2 design gaps in 1 resource


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 1 |
| High | 0 |
| Moderate | 1 |
| Low | 0 |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `k8s_cluster` | # Drata: Ensure that [azurerm_kubernetes_cluster.api_server_authorized_ip_ranges] is explicitly defined and narrowly scoped to only allow trusted sources to access AKS Control Plane<br> Set [azurerm_kubernetes_cluster.network_profile.network_policy] to any of ['azure', 'calico', 'cilium'] to define access policy specifications for communication between Pods<br> |
