### PR TITLE
Drata Compliance Recommendations: Cloud Storage Versioning Enabled

### DIFF
--- a/terraform/gcp/gcs.tf
+++ b/terraform/gcp/gcs.tf
@@ -1,4 +1,5 @@
 resource "google_storage_bucket" "terragoat_website" {
+  # Drata: Set [google_storage_bucket.versioning.enabled] to true to enable infrastructure versioning and prevent accidental deletions and overrides
   name          = "terragot-${var.environment}"
   location      = var.location
   force_destroy = true


### PR DESCRIPTION
## Drata identified 2 design gaps in 2 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 0 |
| High | 2 |
| Moderate | 0 |
| Low | 0 |
### Remediated (2)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `allow_public_read` | # Drata: Set [google_storage_bucket.versioning.enabled] to true to enable infrastructure versioning and prevent accidental deletions and overrides<br> |
### Unremediated (1)
These 1 design gap(s) cannot be remediated automatically. Details for remediation can be found below and within the comments included in this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `data` | Set [aws_s3_bucket_versioning.versioning_configuration.status] to Enabled to enable infrastructure versioning and prevent accidental deletions and overrides<br> |
