### PR TITLE
Drata Compliance Recommendations: Access Policies Restrict Broad Access

### DIFF
--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -208,6 +208,7 @@ resource "aws_iam_role_policy" "ec2policy" {
   role = aws_iam_role.ec2role.id
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns
   # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns
 {
   "Version": "2012-10-17",

--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -208,6 +208,7 @@ resource "aws_iam_role_policy" "ec2policy" {
   role = aws_iam_role.ec2role.id
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -27,6 +27,7 @@ resource "aws_iam_user_policy" "userpolicy" {
   user = "${aws_iam_user.user.name}"
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_user_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns. It is recommended to use group policies over user policies when possible.
   # Drata: Explicitly scope [aws_iam_user_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns. It is recommended to use group policies over user policies when possible.
 {
   "Version": "2012-10-17",

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -27,6 +27,7 @@ resource "aws_iam_user_policy" "userpolicy" {
   user = "${aws_iam_user.user.name}"
 
   policy = <<EOF
+  # Drata: Explicitly scope [aws_iam_user_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns. It is recommended to use group policies over user policies when possible.
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/terraform/aws/kms.tf
+++ b/terraform/aws/kms.tf
@@ -1,4 +1,5 @@
 resource "aws_kms_key" "logs_key" {
+  # Drata: Define [aws_kms_key.policy] to restrict access to your resource. Follow the principal of minimum necessary access, ensuring permissions are scoped to trusted entities. Exclude this finding if access to Keys is managed using IAM policies instead of a Key policy
   # key does not have rotation enabled
   description = "${local.resource_prefix.value}-logs bucket key"
 

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -22,6 +22,7 @@ resource "google_bigquery_dataset" "dataset" {
   dataset_id = "terragoat_${var.environment}_dataset"
   access {
     special_group = "allAuthenticatedUsers"
+    # Drata: Explicitly scope [google_bigquery_dataset.access.special_group] to ensure minimum necessary access. Avoid using insecure allow-all ([allusers, allauthenticatedusers]) access patterns
     role          = "READER"
   }
   labels = {


### PR DESCRIPTION
## Drata identified 6 design gaps in 4 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 6 |
| High | 0 |
| Moderate | 0 |
| Low | 0 |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `dataset` | # Drata: Explicitly scope [google_bigquery_dataset.access.special_group] to ensure minimum necessary access. Avoid using insecure allow-all ([allusers, allauthenticatedusers]) access patterns<br> |
| Critical | `ec2role` | # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns<br> # Drata: Explicitly scope [aws_iam_role.inline_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns<br> |
| Critical | `logs_key_alias` | # Drata: Define [aws_kms_key.policy] to restrict access to your resource. Follow the principal of minimum necessary access, ensuring permissions are scoped to trusted entities. Exclude this finding if access to Keys is managed using IAM policies instead of a Key policy<br> |
| Critical | `user` | # Drata: Explicitly scope [aws_iam_user_policy.policy] action to ensure minimum necessary access. Avoid using insecure allow-all (*) access patterns. It is recommended to use group policies over user policies when possible.<br> # Drata: Explicitly scope [aws_iam_user_policy.policy] resource to ensure minimum necessary access. Avoid using insecure allow-all ([*]) access patterns. It is recommended to use group policies over user policies when possible.<br> |
