### PR TITLE
Drata Compliance Recommendations: Zone Redundancy Configured

### DIFF
--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -14,7 +14,7 @@ resource "aws_db_instance" "default" {
   username                = "admin"
   password                = var.password
   apply_immediately       = true
-  multi_az                = false
+  multi_az                = true
   backup_retention_period = 0
   storage_encrypted       = false
   skip_final_snapshot     = true

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -18,6 +18,7 @@ resource "aws_elb" "weblb" {
   }
 
   subnets                     = [aws_subnet.web_subnet.id]
+  # Drata: Configure [aws_elb.subnets] to improve infrastructure availability and resilience. Define at least 2 subnets or availability zones on your load balancer to enable zone redundancy
   security_groups             = [aws_security_group.web-node.id]
   instances                   = [aws_instance.web_host.id]
   cross_zone_load_balancing   = true

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"
 

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -47,6 +47,7 @@ resource "aws_rds_cluster" "app3-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app4-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app4-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -95,6 +95,7 @@ resource "aws_rds_cluster" "app6-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app7-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app7-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -15,6 +15,7 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app2-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app2-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 1

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -63,6 +63,7 @@ resource "aws_rds_cluster" "app4-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app5-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app5-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -128,6 +128,7 @@ resource "aws_rds_cluster" "app8-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app9-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app9-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -1,4 +1,5 @@
 resource "aws_rds_cluster" "app1-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app1-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 0

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -79,6 +79,7 @@ resource "aws_rds_cluster" "app5-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app6-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app6-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -111,6 +111,7 @@ resource "aws_rds_cluster" "app7-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app8-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app8-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -31,6 +31,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app3-rds-cluster" {
+  # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience
   cluster_identifier      = "app3-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/azure/application_gateway.tf
+++ b/terraform/azure/application_gateway.tf
@@ -5,7 +5,7 @@ resource "azurerm_application_gateway" "network" {
 
   sku {
     name     = "Standard_Small"
-    tier     = "Standard"
+    tier     = "Standard" # Drata: sku.tier should be set to any of Standard_V2, WAF_V2
     capacity = 2
   }
 

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -4,6 +4,7 @@ resource "azurerm_storage_account" "security_storage_account" {
   location                  = azurerm_resource_group.example.location
   account_tier              = "Standard"
   account_replication_type  = "LRS"
+  # Drata: Configure [azurerm_storage_account.account_replication_type] to improve infrastructure availability and resilience. To create highly available Storage Accounts, set azurerm_storage_account.account_replication_type to a geo-redundant storage option by selecting one of the following SKUs: ['standard_grs', 'standard_gzrs', 'standard_ragrs', 'standard_ragzrs', 'grs', 'gzrs', 'ragrs', 'ragzrs']
   enable_https_traffic_only = true
   tags = {
     git_commit           = "a1d1c1ce31a1bde6dafa188846d90eca82abe5fd"


### PR DESCRIPTION
## Drata identified 14 design gaps in 14 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 0 |
| High | 0 |
| Moderate | 13 |
| Low | 1 |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `app1-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app2-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app3-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app4-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app5-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app6-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app7-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app8-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `app9-rds-cluster` | # Drata: Configure [aws_rds_cluster.availability_zones] to improve infrastructure availability and resilience<br> |
| Moderate | `default` | Set [aws_db_instance.multi_az] to true to improve infrastructure availability and resilience<br> |
| Moderate | `monitoring-framework` | # Drata: Set [aws_elasticsearch_domain.cluster_config.zone_awareness_enabled] to true to improve infrastructure availability and resilience<br> |
| Low | `network` | Zone Redundancy is only available with the following SKU(s): [Standard_V2, WAF_V2]. Ensure that [azurerm_application_gateway.sku.tier] is deployed with one of these SKUs to allow Zone Redundancy<br> |
| Moderate | `security_storage_account` | # Drata: Configure [azurerm_storage_account.account_replication_type] to improve infrastructure availability and resilience. To create highly available Storage Accounts, set azurerm_storage_account.account_replication_type to a geo-redundant storage option by selecting one of the following SKUs: ['standard_grs', 'standard_gzrs', 'standard_ragrs', 'standard_ragzrs', 'grs', 'gzrs', 'ragrs', 'ragzrs']<br> |
| Moderate | `weblb` | # Drata: Configure [aws_elb.subnets] to improve infrastructure availability and resilience. Define at least 2 subnets or availability zones on your load balancer to enable zone redundancy<br> |
