### PR TITLE
Drata Compliance Recommendations: Secure TLS/SSL Configuration

### DIFF
--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.tls_security_policy] to Policy-Min-TLS-1-2-2019-07 to ensure security policies are configured using the latest secure TLS version
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"
 

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -1,4 +1,5 @@
 resource "azurerm_storage_account" "security_storage_account" {
+  # Drata: Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version
   name                      = "securitystorageaccount-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name       = azurerm_resource_group.example.name
   location                  = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -21,7 +21,7 @@ resource "azurerm_mssql_server" "mssql1" {
   name                         = "terragoat-mssql1-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -59,7 +59,7 @@ resource "azurerm_mssql_server" "mssql3" {
   name                         = "mssql3-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -135,7 +135,7 @@ resource "azurerm_mssql_server" "mssql7" {
   name                         = "mssql7-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -78,7 +78,7 @@ resource "azurerm_mssql_server" "mssql4" {
   name                         = "mssql4-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -116,7 +116,7 @@ resource "azurerm_mssql_server" "mssql6" {
   name                         = "mssql6-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -40,7 +40,7 @@ resource "azurerm_mssql_server" "mssql2" {
   name                         = "mssql2-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -97,7 +97,7 @@ resource "azurerm_mssql_server" "mssql5" {
   name                         = "mssql5-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
-  version                      = "12.0"
+  version                      = 1.2
   administrator_login          = "missadministrator"
   administrator_login_password = "AdminPassword123!"
   tags = {

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -37,7 +37,7 @@ resource "azurerm_storage_account" "example" {
     hour_metrics {
       enabled               = true
       include_apis          = true
-      version               = "1.0"
+      version               = "TLS1_2"
       retention_policy_days = 10
     }
     minute_metrics {


### PR DESCRIPTION
## Drata identified 10 design gaps in 10 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 10 |
| High | 0 |
| Moderate | 0 |
| Low | 0 |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `alertpolicy1` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `alertpolicy2` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `alertpolicy3` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `alertpolicy4` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `alertpolicy5` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `alertpolicy6` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `alertpolicy7` | Set [azurerm_mssql_server.minimum_tls_version] to 1.2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `example` | Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `monitoring-framework` | # Drata: Set [aws_elasticsearch_domain.domain_endpoint_options.tls_security_policy] to Policy-Min-TLS-1-2-2019-07 to ensure security policies are configured using the latest secure TLS version<br> |
| Critical | `security_storage_account` | # Drata: Set [azurerm_storage_account.min_tls_version] to TLS1_2 to ensure security policies are configured using the latest secure TLS version<br> |
