### PR TITLE
Drata Compliance Recommendations: Public Access Restricted

### DIFF
--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "default" {
   storage_encrypted       = false
   skip_final_snapshot     = true
   monitoring_interval     = 0
-  publicly_accessible     = true
+  publicly_accessible     = false
 
   tags = merge({
     Name        = "${local.resource_prefix.value}-rds"

--- a/terraform/aws/ec2.tf
+++ b/terraform/aws/ec2.tf
@@ -136,7 +136,7 @@ resource "aws_subnet" "web_subnet" {
   vpc_id                  = aws_vpc.web_vpc.id
   cidr_block              = "172.16.10.0/24"
   availability_zone       = "${var.region}a"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = merge({
     Name = "${local.resource_prefix.value}-subnet"

--- a/terraform/aws/ec2.tf
+++ b/terraform/aws/ec2.tf
@@ -156,7 +156,7 @@ resource "aws_subnet" "web_subnet2" {
   vpc_id                  = aws_vpc.web_vpc.id
   cidr_block              = "172.16.11.0/24"
   availability_zone       = "${var.region}b"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = merge({
     Name = "${local.resource_prefix.value}-subnet2"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -91,7 +91,7 @@ resource aws_subnet "eks_subnet2" {
   vpc_id                  = aws_vpc.eks_vpc.id
   cidr_block              = "10.10.11.0/24"
   availability_zone       = "${var.region}b"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
   tags = merge({
     Name                                            = "${local.resource_prefix.value}-eks-subnet2"
     "kubernetes.io/cluster/${local.eks_name.value}" = "shared"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -63,7 +63,7 @@ resource aws_subnet "eks_subnet1" {
   vpc_id                  = aws_vpc.eks_vpc.id
   cidr_block              = "10.10.10.0/24"
   availability_zone       = "${var.region}a"
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
   tags = merge({
     Name                                            = "${local.resource_prefix.value}-eks-subnet"
     "kubernetes.io/cluster/${local.eks_name.value}" = "shared"

--- a/terraform/aws/elb.tf
+++ b/terraform/aws/elb.tf
@@ -1,5 +1,6 @@
 # Create a new load balancer
 resource "aws_elb" "weblb" {
+  # Drata: Configure [aws_elb.internal] to true to disable public access. It is recommended to explicitly allow access to trusted users or IPs. Exclude this finding if your business use-case requires ELB V1 to be publicly available
   name = "weblb-terraform-elb"
 
   listener {

--- a/terraform/azure/key_vault.tf
+++ b/terraform/azure/key_vault.tf
@@ -1,4 +1,5 @@
 resource "azurerm_key_vault" "example" {
+  # Drata: Configure [azurerm_key_vault.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. If your business use-case requires public access, define [microsoft_key_vault.vaults.network_acls] appropriately to restrict access
   name                = "terragoat-key-${var.environment}${random_integer.rnd_int.result}"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -56,6 +56,7 @@ resource "azurerm_mssql_server" "mssql2" {
 }
 
 resource "azurerm_mssql_server" "mssql3" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql3-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -37,6 +37,7 @@ resource "azurerm_mssql_server" "mssql1" {
 }
 
 resource "azurerm_mssql_server" "mssql2" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql2-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -132,6 +132,7 @@ resource "azurerm_mssql_server" "mssql6" {
 }
 
 resource "azurerm_mssql_server" "mssql7" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql7-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -1,4 +1,5 @@
 resource "azurerm_storage_account" "security_storage_account" {
+  # Drata: Configure [azurerm_storage_account.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. For Storage Accounts that don't require public access it is recommended to use private endpoints to only grant private access
   name                      = "securitystorageaccount-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name       = azurerm_resource_group.example.name
   location                  = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -113,6 +113,7 @@ resource "azurerm_mssql_server" "mssql5" {
 }
 
 resource "azurerm_mssql_server" "mssql6" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql6-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -18,6 +18,7 @@ resource "azurerm_storage_account" "security_storage_account" {
 }
 
 resource "azurerm_mssql_server" "mssql1" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "terragoat-mssql1-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -75,6 +75,7 @@ resource "azurerm_mssql_server" "mssql3" {
 }
 
 resource "azurerm_mssql_server" "mssql4" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql4-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/azure/mssql.tf
+++ b/terraform/azure/mssql.tf
@@ -94,6 +94,7 @@ resource "azurerm_mssql_server" "mssql4" {
 }
 
 resource "azurerm_mssql_server" "mssql5" {
+  # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs
   name                         = "mssql5-${var.environment}${random_integer.rnd_int.result}"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location

--- a/terraform/gcp/big_data.tf
+++ b/terraform/gcp/big_data.tf
@@ -14,6 +14,7 @@ resource "google_sql_database_instance" "master_instance" {
     }
     backup_configuration {
       enabled = false
+    # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance
     }
   }
 }


### PR DESCRIPTION
## Drata identified 19 design gaps in 19 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 1 |
| High | 12 |
| Moderate | 6 |
| Low | 0 |
### Remediated (2)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| High | `alertpolicy1` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `alertpolicy2` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `alertpolicy3` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `alertpolicy4` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `alertpolicy5` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `alertpolicy6` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `alertpolicy7` | # Drata: Configure [azurerm_mssql_server.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| High | `default` | Configure [aws_db_instance.publicly_accessible] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs<br> |
| Moderate | `eks_subnet1` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| Moderate | `eks_subnet2` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| High | `generated` | # Drata: Configure [azurerm_key_vault.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. If your business use-case requires public access, define [microsoft_key_vault.vaults.network_acls] appropriately to restrict access<br> |
| Moderate | `master_instance` | # Drata: Ensure that SQL database instance is not publicly accessible by giving it a private IP. Define [google_sql.sql_database_instance.settings.ip_configuration.private_network] to use private IPs while connecting to SQL database instance<br> |
| Moderate | `rtbassoc` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| Moderate | `rtbassoc2` | Set [aws_subnet.map_public_ip_on_launch] to false to prevent the automatic assignment of public IP addresses to EC2 Instances of this subnet<br> |
| High | `security_storage_account` | # Drata: Configure [azurerm_storage_account.public_network_access_enabled] to false to disable public access. It is recommended to explicitly allow access to trusted users or IPs. For Storage Accounts that don't require public access it is recommended to use private endpoints to only grant private access<br> |
| High | `weblb` | # Drata: Configure [aws_elb.internal] to true to disable public access. It is recommended to explicitly allow access to trusted users or IPs. Exclude this finding if your business use-case requires ELB V1 to be publicly available<br> |
### Unremediated (3)
These 3 design gap(s) cannot be remediated automatically. Details for remediation can be found below and within the comments included in this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Critical | `data` | Configure [s3.bucket.public_access_block_configuration] to prevent intentional or incidental public access<br> |
| High | `data_science` | Configure [aws_s3_bucket_acl.acl] to prevent intentional or incidental public access. It is recommended to use [s3.bucket.public_access_block_configuration] to control S3 bucket public access over Canned Access Control Lists (ACLs)<br> |
| Moderate | `financials` | It is recommended to use [s3.bucket.public_access_block_configuration] to control S3 bucket public access over Canned Access Control Lists (ACLs)<br> |
