### PR TITLE
Drata Compliance Recommendations: Transparent Data-at-Rest Encryption Enabled

### DIFF
--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "default" {
   apply_immediately       = true
   multi_az                = false
   backup_retention_period = 0
-  storage_encrypted       = false
+  storage_encrypted       = true
   skip_final_snapshot     = true
   monitoring_interval     = 0
   publicly_accessible     = true

--- a/terraform/aws/es.tf
+++ b/terraform/aws/es.tf
@@ -1,4 +1,5 @@
 resource "aws_elasticsearch_domain" "monitoring-framework" {
+  # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled
   domain_name           = "tg-${var.environment}-es"
   elasticsearch_version = "2.3"
 

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -47,6 +47,7 @@ resource "aws_rds_cluster" "app3-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app4-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app4-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -63,6 +63,7 @@ resource "aws_rds_cluster" "app4-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app5-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app5-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -128,6 +128,7 @@ resource "aws_rds_cluster" "app8-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app9-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app9-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -15,6 +15,7 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app2-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app2-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 1

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -111,6 +111,7 @@ resource "aws_rds_cluster" "app7-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app8-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app8-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -31,6 +31,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app3-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app3-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -1,4 +1,5 @@
 resource "aws_rds_cluster" "app1-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app1-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 0

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -95,6 +95,7 @@ resource "aws_rds_cluster" "app6-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app7-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app7-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 25

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -79,6 +79,7 @@ resource "aws_rds_cluster" "app5-rds-cluster" {
 }
 
 resource "aws_rds_cluster" "app6-rds-cluster" {
+  # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled
   cluster_identifier      = "app6-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 15

--- a/terraform/azure/instance.tf
+++ b/terraform/azure/instance.tf
@@ -42,6 +42,7 @@ resource azurerm_linux_virtual_machine "linux_machine" {
 }
 
 resource azurerm_windows_virtual_machine "windows_machine" {
+  # Drata: Set [azurerm_windows_virtual_machine.encryption_at_host_enabled] to true to ensure transparent data encryption is enabled. This setting ensures temporary disks, caches, and data flows between Azure VM and Storage are encrypted.
   admin_password        = random_string.password.result
   admin_username        = "tg-${var.environment}"
   location              = var.location

--- a/terraform/gcp/gke.tf
+++ b/terraform/gcp/gke.tf
@@ -4,6 +4,7 @@ data "google_compute_zones" "available_zones" {
 }
 
 resource "google_container_cluster" "workload_cluster" {
+  # Drata: Kubernetes provides an additional layer of security for sensitive data, such as Secrets, stored in etcd. Using this functionality, you can use a key managed by your Cloud provider to encrypt data at the etcd layer. This encryption protects against attackers who gain access to an offline copy of etcd. Ensure that [google_container_cluster.database_encryption.state] properties are correctly defined for encrypting secrets
   name               = "terragoat-${var.environment}-cluster"
   logging_service    = "none"
   location           = var.region


### PR DESCRIPTION
## Drata identified 14 design gaps in 14 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 0 |
| High | 1 |
| Moderate | 13 |
| Low | 0 |
### Remediated (2)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `app1-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app2-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app3-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app4-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app5-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app6-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app7-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app8-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `app9-rds-cluster` | # Drata: Set [aws_rds_cluster.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| High | `custom_node_pool` | # Drata: Kubernetes provides an additional layer of security for sensitive data, such as Secrets, stored in etcd. Using this functionality, you can use a key managed by your Cloud provider to encrypt data at the etcd layer. This encryption protects against attackers who gain access to an offline copy of etcd. Ensure that [google_container_cluster.database_encryption.state] properties are correctly defined for encrypting secrets<br> |
| Moderate | `default` | Set [aws_db_instance.storage_encrypted] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `monitoring-framework` | # Drata: Set [aws_elasticsearch_domain.encrypt_at_rest.enabled] to true to ensure transparent data encryption is enabled<br> |
| Moderate | `windows_machine` | # Drata: Set [azurerm_windows_virtual_machine.encryption_at_host_enabled] to true to ensure transparent data encryption is enabled. This setting ensures temporary disks, caches, and data flows between Azure VM and Storage are encrypted.<br> |
### Unremediated (1)
These 1 design gap(s) cannot be remediated automatically. Details for remediation can be found below and within the comments included in this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `linux_machine` | Set [azurerm_windows_virtual_machine.encryption_at_host_enabled] to true to ensure transparent data encryption is enabled. This setting ensures temporary disks, caches, and data flows between Azure VM and Storage are encrypted.<br> |
