### PR TITLE
Drata Compliance Recommendations: Backup Retention Configured

### DIFF
--- a/terraform/aws/db-app.tf
+++ b/terraform/aws/db-app.tf
@@ -16,6 +16,7 @@ resource "aws_db_instance" "default" {
   apply_immediately       = true
   multi_az                = false
   backup_retention_period = 0
+  # Drata: Specify [aws_db_instance.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups
   storage_encrypted       = false
   skip_final_snapshot     = true
   monitoring_interval     = 0

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -2,6 +2,7 @@ resource "aws_rds_cluster" "app1-rds-cluster" {
   cluster_identifier      = "app1-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 0
+  # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups
   tags = {
     git_commit           = "079fe74f6b96d887c245664fbd8cf676c92f20e5"
     git_file             = "terraform/aws/rds.tf"

--- a/terraform/aws/rds.tf
+++ b/terraform/aws/rds.tf
@@ -18,6 +18,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
   cluster_identifier      = "app2-rds-cluster"
   allocated_storage       = 10
   backup_retention_period = 1
+  # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. It is recommended to configure a non-default value appropriate for your specific use-case. AWS defaults to 7 days
   tags = {
     git_commit           = "079fe74f6b96d887c245664fbd8cf676c92f20e5"
     git_file             = "terraform/aws/rds.tf"


### PR DESCRIPTION
## Drata identified 3 design gaps in 3 resources


View your full validation results in [Drata](https://app-04.dev.drata.com/compliance/monitoring/code)
| Severity                    | Gaps |
| ----------- | ---------- |
| Critical | 0 |
| High | 0 |
| Moderate | 3 |
| Low | 0 |
### Remediated (1)
Remediate these design gaps by merging this pull request.
 
| Severity    | Resource Name                    | Fix |
| ------------- | --------------------------- | ---------- |
| Moderate | `app1-rds-cluster` | # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups<br> |
| Moderate | `app2-rds-cluster` | # Drata: Specify [aws_rds_cluster.backup_retention_period] to ensure sensitive data is only available when necessary. It is recommended to configure a non-default value appropriate for your specific use-case. AWS defaults to 7 days<br> |
| Moderate | `default` | # Drata: Specify [aws_db_instance.backup_retention_period] to ensure sensitive data is only available when necessary. Setting backup retention to 0 will disable automatic backups<br> |
